### PR TITLE
Merging of rocko_dev to Rocko

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Getting Started
 
     Tell Repo where to find the manifest
 
-        $ repo init -u git://github.com/balister/oe-gnuradio-manifest.git -b stable
+        $ repo init -u git://github.com/Geontech/e300-manifest.git -b rocko_dev
 
     A successful initialization will end with a message stating that Repo is
     initialized in your working directory. Your client directory should now
@@ -47,19 +47,19 @@ Getting Started
     **Note**
     You can use the **-b** switch to specify the branch of the repository
     to use.  I develop on master so it might be iffy at times. Use the
-    "stable" branch fornormal work. 
+    "stable" branch fornormal work.
 
     The **-m** switch selects the manifest file (default is *default.xml*).
 
     To test out the bleeding edge, type:
 
         $ repo init -u git://github.com/balister/oe-gnuradio-manifest.git
-    
+
     To get back to the known stable version, type:
 
         $ repo init -u git://github.com/balister/oe-gnuradio-manifest -b stable
 
-    To learn more about repo, look at http://source.android.com/source/version-control.html 
+    To learn more about repo, look at http://source.android.com/source/version-control.html
     ***
 
 3.  Fetch all the repositories.
@@ -72,7 +72,7 @@ Getting Started
 4.  Initialize the OpenEmbedded Environment. This assumes you created the oe-core directory
     in your home directory.
 
-        $ TEMPLATECONF=`pwd`/meta-sdr/conf source ./oe-core/oe-init-build-env ./build ./bitbake
+        $ TEMPLATECONF=`pwd`/meta-redhawk-apps/conf/ source ./openembedded-core/oe-init-build-env ./build ./bitbake
 
     This copies default configuration information into the build/conf*
     directory and sets up some environment variables for OpenEmbedded.  You may
@@ -84,8 +84,8 @@ Getting Started
     do an awful lot of compilation so make sure you have plenty of space (25GB
     minimum). Go drink some beer.
 
-        $ export MACHINE="zedboard-zynq7" (default is ettus-e1xx)
-        $ bitbake gnuradio-dev-image
+        $ export MACHINE=ettus-e3xx-sg1
+        $ bitbake redhawk-base-image
 
     If everything goes well, you should have a compressed root filesystem
     tarball as well as kernel and bootloader binaries available in your
@@ -100,8 +100,8 @@ Getting Started
 
     Run:
 
-        $ export MACHINE="zedboard-zynq7" (only if MACHINE is not already set)
-        $ bitbake -c populate_sdk gnuradio-dev-image
+        $ export MACHINE=ettus-e3xx-sg1 (only if MACHINE is not already set)
+        $ bitbake -c populate_sdk redhawk-base-image
 
     When this completes the sdk is in ./tmp-eglibc/deploy/sdk/ as an .sh file
     you copy to the machine you want to cross compile on and run the file.
@@ -116,7 +116,7 @@ To pick up the latest changes for all source repositories, run:
 
 Enter the OpenEmbedded environment:
 
-    $ . oe-core/oe-init-build-env ./build ./bitbake
+    $ . openembedded-core/oe-init-build-env ./build ./bitbake
 
     If you forget to setup these environment variables prior to running bitbake,
     your OS will complain that it can't find bitbake on the path.  Don't try
@@ -124,7 +124,7 @@ Enter the OpenEmbedded environment:
 
 You can then rebuild as before:
 
-    $ bitbake gnuradio-dev-image
+    $ bitbake redhawk-base-image
 
 Starting from Fresh
 -------------------
@@ -147,7 +147,7 @@ repositories and branches or pull in additional meta-layers.
 
 Clone this repository (or fork it on github):
 
-    $ git clone git://github.com/balister/oe-gnuradio-manifest.git
+    $ git clone https://github.com/Geontech/e300-manifest.git -b rocko_dev
 
 Make your changes (and contribute them back if they are generally useful :) ),
 and then re-initialize your repo client
@@ -164,4 +164,3 @@ These machines have been tested:
  imx6sabre-lite
 
 Please send success stories to philip@balister.org.
-

--- a/README.md
+++ b/README.md
@@ -94,6 +94,30 @@ and run the script:
 
         $ /usr/lib/uhd/utils/uhd_images_downloader.py
 
+Stand-alone Build
+-----------------
+
+Do you want your E310 to be a stand-alone REDHAWK Domain complete with components, a GPP, etc.?  The `redhawk-usrp-uhd-image` does not include many of those elements, but each can be easily added by either defining a new image or extending the target image from your `build/conf/local.conf` file:
+
+```
+CORE_IMAGE_EXTRA_INSTALL_append = "\
+    omniorb-init \
+    omnievents-init \
+    domain-init \
+    node-deployer \
+    gpp \
+    packagegroup-redhawk-basic-components \
+    packagegroup-redhawk-basic-softpkgs \
+"
+COMPATIBLE_MACHINE_pn-sse2neon = "ettus-e300"
+```
+
+The first change to `CORE_IMAGE_EXTRA_INSTALL` ensures that the init.d services for OmniNames, OmniEvents, and the Domain are all installed.  The inclusion of the gpp and node-deployer packages will result in a `-ALL` device manager definition being installed that contains both the GPP and the USRP UHD Device.  The last two lines are the package groups for components and softpkgs defined in the layer.
+
+The second change to `COMPATIBLE_MACHINE` addresses the lack of `arm` in the E3xx build environment's `MACHINEOVERRIDES` variable, which prevents the associated `sse2neon` package from being built, which would then prevent the `rh.DataConverter` from being built, and so on.
+
+Between these two changes, the next time you run `bitbake redhawk-usrp-uhd-image`, your root file system will be ready to act as a stand-alone REDHAWK Domain.
+
 Staying Up to Date
 ------------------
 To pick up the latest changes for all source repositories, run:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ CORE_IMAGE_EXTRA_INSTALL_append = "\
     omnievents-init \
     domain-init \
     node-deployer \
-    gpp \
+    gpp gpp-node \
     packagegroup-redhawk-basic-components \
     packagegroup-redhawk-basic-softpkgs \
 "

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Getting Started
 10. After building the image and getting it up and running, ssh into the E310
 and run the script:
 
-    $ /usr/lib/uhd/utils/uhd_images_downloader.py
+        $ /usr/lib/uhd/utils/uhd_images_downloader.py
 
 Staying Up to Date
 ------------------

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Getting Started
 
     Create an empty directory to hold your working files.
 
-        $ mkdir oe-repo
-        $ cd oe-repo
+        $ mkdir e300-build
+        $ cd e300-build
 
     Tell Repo where to find the manifest
 
@@ -44,24 +44,6 @@ Getting Started
     initialized in your working directory. Your client directory should now
     contain a .repo directory where files such as the manifest will be kept.
     ***
-    **Note**
-    You can use the **-b** switch to specify the branch of the repository
-    to use.  I develop on master so it might be iffy at times. Use the
-    "stable" branch fornormal work.
-
-    The **-m** switch selects the manifest file (default is *default.xml*).
-
-    To test out the bleeding edge, type:
-
-        $ repo init -u git://github.com/balister/oe-gnuradio-manifest.git
-
-    To get back to the known stable version, type:
-
-        $ repo init -u git://github.com/balister/oe-gnuradio-manifest -b stable
-
-    To learn more about repo, look at http://source.android.com/source/version-control.html
-    ***
-
 3.  Fetch all the repositories.
 
         $ repo sync
@@ -69,23 +51,34 @@ Getting Started
     Now go put on the coffee machine as this may take 20 minutes depending on
     your connection.
 
-4.  Initialize the OpenEmbedded Environment. This assumes you created the oe-core directory
-    in your home directory.
+4.  Go into the sdr-build directory:
 
-        $ TEMPLATECONF=`pwd`/meta-redhawk-apps/conf/ source ./openembedded-core/oe-init-build-env ./build ./bitbake
+        $ cd sdr-build
 
-    This copies default configuration information into the build/conf*
-    directory and sets up some environment variables for OpenEmbedded.  You may
-    wish to edit the configuration options at this point.
+5.  Update the submodules:
 
-5.  Build an image.
+        $ git submodule update --init
+
+6.  Move the meta-redhawk-sdr directory into the sdr-build directory   
+
+7.  Initialize the build system
+
+        $ TEMPLATECONF=`pwd`/meta-sdr/conf/conf-e3xx/ source ./openembedded-core/oe-init-build-env ./build ./bitbake
+
+8.  Go into the build directory and edit the bblayers.conf file by adding the line:
+
+    ```PATH_TO_sdr-build/meta-redhawk-sdr \```
+
+    where "PATH_TO_sdr-build" is the absolute path to the directory "sdr-build"
+
+9.  Build an image.
 
     This process downloads several gigabytes of source code and then proceeds to
     do an awful lot of compilation so make sure you have plenty of space (25GB
     minimum). Go drink some beer.
 
-        $ export MACHINE=ettus-e3xx-sg1
-        $ bitbake redhawk-base-image
+        $ export MACHINE=ettus-e3xx-sg3
+        $ bitbake redhawk-usrp-uhd-image
 
     If everything goes well, you should have a compressed root filesystem
     tarball as well as kernel and bootloader binaries available in your
@@ -96,17 +89,10 @@ Getting Started
     a look to be sure your operating system is supported:
     https://wiki.yoctoproject.org/wiki/Distribution_Support
 
-6.  Build an SDK for cross compiling gnuradio on an x86 machine.
+10. After building the image and getting it up and running, ssh into the E310
+and run the script:
 
-    Run:
-
-        $ export MACHINE=ettus-e3xx-sg1 (only if MACHINE is not already set)
-        $ bitbake -c populate_sdk redhawk-base-image
-
-    When this completes the sdk is in ./tmp-eglibc/deploy/sdk/ as an .sh file
-    you copy to the machine you want to cross compile on and run the file.
-    It will default to installing the sdk in /usr/local, and you can ask it to
-    install anywhere you have write access to.
+    $ /usr/lib/uhd/utils/uhd_images_downloader.py
 
 Staying Up to Date
 ------------------
@@ -124,7 +110,7 @@ Enter the OpenEmbedded environment:
 
 You can then rebuild as before:
 
-    $ bitbake redhawk-base-image
+    $ bitbake redhawk-usrp-uhd-image
 
 Starting from Fresh
 -------------------
@@ -153,14 +139,5 @@ Make your changes (and contribute them back if they are generally useful :) ),
 and then re-initialize your repo client
 
     $ repo init -u <file:///path/to/your/git/repository.git>
-
-Known Good Machines
--------------------
-
-These machines have been tested:
-
- zedboard-zynq7
- ettus-e1xx (need to use kernel+modules from official image)
- imx6sabre-lite
 
 Please send success stories to philip@balister.org.

--- a/default.xml
+++ b/default.xml
@@ -11,5 +11,5 @@
 	<default remote="openembedded" revision="master"  />
 
 	<project name="sdr-build" remote="balister" path="" revision="rocko-e300"/>
-	<project name="meta-redhawk-sdr" remote="geon" path="meta-redhawk-sdr" revision="master"/>
+	<project name="meta-redhawk-sdr" remote="geon" path="meta-redhawk-sdr" revision="rocko"/>
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -10,7 +10,7 @@
 	<remote name="qt5" fetch="https://github.com/meta-qt5/" />
 	<default remote="openembedded" revision="master"  />
 
-	<project name="bitbake" remote="openembedded" path="1.36"/>
+	<project name="bitbake" remote="openembedded" path="bitbake" revision="1.36"/>
 	<project name="openembedded-core" remote="openembedded" path="openembedded-core" revision="rocko"/>
 	<project name="meta-openembedded" remote="openembedded" path="meta-openembedded" revision="rocko"/>
 	<project name="meta-sdr" remote="balister" path="meta-sdr" revision="rocko"/>

--- a/default.xml
+++ b/default.xml
@@ -3,22 +3,13 @@
 <manifest>
 	<remote name="openembedded" fetch="git://github.com/openembedded" />
 	<remote name="Xilinx" fetch="git://github.com/Xilinx" />
-  <remote name="yocto" fetch="git://git.yoctoproject.org/" />
+    <remote name="yocto" fetch="git://git.yoctoproject.org/" />
 	<remote name="ettus" fetch="http://github.com/EttusResearch" />
 	<remote name="geon" fetch="https://github.com/GeonTech/" revision="master" />
 	<remote name="balister" fetch="git://github.com/balister" />
 	<remote name="qt5" fetch="https://github.com/meta-qt5/" />
 	<default remote="openembedded" revision="master"  />
 
-	<project name="meta-cloud-services" remote="yocto" path="poky/meta-cloud-services" revision="rocko"/>
-	<project name="bitbake" remote="openembedded" path="bitbake" revision="1.36"/>
-  <project name="poky" remote="yocto" path="poky" revision="rocko"/>
-	<project name="openembedded-core" remote="openembedded" path="poky/openembedded-core" revision="rocko"/>
-	<project name="meta-openembedded" remote="openembedded" path="poky/meta-openembedded" revision="rocko"/>
-	<project name="meta-sdr" remote="balister" path="poky/meta-sdr" revision="rocko"/>
-	<project name="meta-qt5" remote="qt5" path="poky/meta-qt5" revision="rocko"/>
-	<project name="meta-ettus-1" remote="balister" path="poky/meta-ettus" revision="rocko-updates"/>
-	<project name="meta-xilinx" remote="Xilinx" path="poky/meta-xilinx" revision="rocko"/>
-	<project name="meta-redhawk-sdr" remote="geon" path="poky/meta-redhawk-sdr" revision="master"/>
-	<project name="meta-redhawk-apps" remote="geon" path="poky/meta-redhawk-apps" revision="rocko"/>
+	<project name="sdr-build" remote="balister" path="" revision="rocko-e300"/>
+	<project name="meta-redhawk-sdr" remote="geon" path="meta-redhawk-sdr" revision="master"/>
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -10,6 +10,7 @@
 	<remote name="qt5" fetch="https://github.com/meta-qt5/" />
 	<default remote="openembedded" revision="master"  />
 
+	<project name="meta-cloud-services" remote="yocto" path="meta-cloud-services" revision="rocko"/>
 	<project name="bitbake" remote="openembedded" path="bitbake" revision="1.36"/>
 	<project name="openembedded-core" remote="openembedded" path="openembedded-core" revision="rocko"/>
 	<project name="meta-openembedded" remote="openembedded" path="meta-openembedded" revision="rocko"/>

--- a/default.xml
+++ b/default.xml
@@ -1,42 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <manifest>
-	<remote name="openembedded"
-		fetch="git://github.com/openembedded" />
-
-	<remote name="Xilinx"
-		fetch="git://github.com/Xilinx" />
-
-	<remote name="balister"
-		fetch="git://github.com/balister" />
-
-        <remote name="yocto"
-                fetch="git://git.yoctoproject.org/" />
-
-        <remote name="ettus"
-                fetch="http://github.com/EttusResearch" />
-
-	<remote name="geon"
-                fetch="https://github.com/GeonTech/" />
-
-	<remote name="qt5"
-		fetch="https://github.com/meta-qt5/" />
-
-	<remote name="yocto"
-		fetch="git://git.yoctoproject.org/" />
-
+	<remote name="openembedded" fetch="git://github.com/openembedded" />
+	<remote name="openembedded-core" fetch="git://github.com/openembedded-core" />
+	<remote name="Xilinx" fetch="git://github.com/Xilinx" />
+  <remote name="yocto" fetch="git://git.yoctoproject.org/" />
+	<remote name="ettus" fetch="http://github.com/EttusResearch" />
+	<remote name="geon" fetch="https://github.com/GeonTech/" revision="master" />
+	<remote name="balister" fetch="git://github.com/balister" />
+	<remote name="qt5" fetch="https://github.com/meta-qt5/" />
 	<default remote="openembedded" revision="master"  />
 
-	<project name="meta-cloud-services" remote="yocto" path="poky/meta-cloud-services" revision="rocko"/>
-	<project name="poky" remote="yocto" path="poky/meta-poky"/>
-	<project name="meta-ettus" remote="ettus" path="poky/meta-ettus" revision="rocko/n3xx"/>
-	<project name="bitbake"  path="poky/bitbake" revision="1.36"/>
-	<project name="openembedded-core"  path="poky/oe-core" revision="rocko"/>
-	<project name="meta-openembedded"  path="poky/meta-oe" revision="rocko"/>
-	<project name="meta-xilinx" remote="Xilinx" path="poky/meta-xilinx" revision="rocko"/>
+	<project name="poky" remote="yocto" path="poky"/>
+	<project name="openembedded-core"  path="poky/openembedded-core" revision="rocko"/>
+	<project name="meta-openembedded"  path="poky/meta-openembedded" revision="rocko"/>
 	<project name="meta-sdr" remote="balister" path="poky/meta-sdr" revision="rocko"/>
 	<project name="meta-qt5" remote="qt5" path="poky/meta-qt5" revision="rocko"/>
-	<project name="meta-redhawk-sdr" remote="geon" path="poky/meta-redhawk-sdr" revision="rocko"/>
+	<project name="meta-ettus" remote="ettus" path="poky/meta-ettus" revision="rocko/n3xx"/>
+	<project name="meta-xilinx" remote="Xilinx" path="poky/meta-xilinx" revision="rocko"/>
+	<project name="meta-redhawk-sdr" remote="geon" path="poky/meta-redhawk-sdr" />
 	<project name="meta-redhawk-apps" remote="geon" path="poky/meta-redhawk-apps" revision="rocko"/>
-
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -2,7 +2,6 @@
 
 <manifest>
 	<remote name="openembedded" fetch="git://github.com/openembedded" />
-	<remote name="openembedded-core" fetch="git://github.com/openembedded-core" />
 	<remote name="Xilinx" fetch="git://github.com/Xilinx" />
   <remote name="yocto" fetch="git://git.yoctoproject.org/" />
 	<remote name="ettus" fetch="http://github.com/EttusResearch" />
@@ -11,13 +10,13 @@
 	<remote name="qt5" fetch="https://github.com/meta-qt5/" />
 	<default remote="openembedded" revision="master"  />
 
-	<project name="poky" remote="yocto" path="poky"/>
-	<project name="openembedded-core"  path="poky/openembedded-core" revision="rocko"/>
-	<project name="meta-openembedded"  path="poky/meta-openembedded" revision="rocko"/>
-	<project name="meta-sdr" remote="balister" path="poky/meta-sdr" revision="rocko"/>
-	<project name="meta-qt5" remote="qt5" path="poky/meta-qt5" revision="rocko"/>
-	<project name="meta-ettus" remote="ettus" path="poky/meta-ettus" revision="rocko/n3xx"/>
-	<project name="meta-xilinx" remote="Xilinx" path="poky/meta-xilinx" revision="rocko"/>
-	<project name="meta-redhawk-sdr" remote="geon" path="poky/meta-redhawk-sdr" />
-	<project name="meta-redhawk-apps" remote="geon" path="poky/meta-redhawk-apps" revision="rocko"/>
+	<project name="bitbake" remote="openembedded" path="1.36"/>
+	<project name="openembedded-core"  path="openembedded-core" revision="rocko"/>
+	<project name="meta-openembedded"  path="meta-openembedded" revision="rocko"/>
+	<project name="meta-sdr" remote="balister" path="meta-sdr" revision="rocko"/>
+	<project name="meta-qt5" remote="qt5" path="meta-qt5" revision="rocko"/>
+	<project name="meta-ettus" remote="ettus" path="meta-ettus" revision="rocko-updates"/>
+	<project name="meta-xilinx" remote="Xilinx" path="meta-xilinx" revision="rocko"/>
+	<project name="meta-redhawk-sdr" remote="geon" path="meta-redhawk-sdr" revision="rocko"/>
+	<project name="meta-redhawk-apps" remote="geon" path="meta-redhawk-apps" revision="rocko"/>
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -3,7 +3,7 @@
 <manifest>
 	<remote name="openembedded" fetch="git://github.com/openembedded" />
 	<remote name="Xilinx" fetch="git://github.com/Xilinx" />
-    <remote name="yocto" fetch="git://git.yoctoproject.org/" />
+	<remote name="yocto" fetch="git://git.yoctoproject.org/" />
 	<remote name="ettus" fetch="http://github.com/EttusResearch" />
 	<remote name="geon" fetch="https://github.com/GeonTech/" revision="master" />
 	<remote name="balister" fetch="git://github.com/balister" />

--- a/default.xml
+++ b/default.xml
@@ -28,6 +28,7 @@
 	<default remote="openembedded" revision="master"  />
 
 	<project name="meta-cloud-services" remote="yocto" path="poky/meta-cloud-services" revision="rocko"/>
+	<project name="poky" remote="yocto" path="poky/meta-poky"/>
 	<project name="meta-ettus" remote="ettus" path="poky/meta-ettus" revision="rocko/n3xx"/>
 	<project name="bitbake"  path="poky/bitbake" revision="1.36"/>
 	<project name="openembedded-core"  path="poky/oe-core" revision="rocko"/>

--- a/default.xml
+++ b/default.xml
@@ -11,8 +11,8 @@
 	<default remote="openembedded" revision="master"  />
 
 	<project name="bitbake" remote="openembedded" path="1.36"/>
-	<project name="openembedded-core"  path="openembedded-core" revision="rocko"/>
-	<project name="meta-openembedded"  path="meta-openembedded" revision="rocko"/>
+	<project name="openembedded-core" remote="openembedded" path="openembedded-core" revision="rocko"/>
+	<project name="meta-openembedded" remote="openembedded" path="meta-openembedded" revision="rocko"/>
 	<project name="meta-sdr" remote="balister" path="meta-sdr" revision="rocko"/>
 	<project name="meta-qt5" remote="qt5" path="meta-qt5" revision="rocko"/>
 	<project name="meta-ettus" remote="ettus" path="meta-ettus" revision="rocko-updates"/>

--- a/default.xml
+++ b/default.xml
@@ -10,14 +10,15 @@
 	<remote name="qt5" fetch="https://github.com/meta-qt5/" />
 	<default remote="openembedded" revision="master"  />
 
-	<project name="meta-cloud-services" remote="yocto" path="meta-cloud-services" revision="rocko"/>
+	<project name="meta-cloud-services" remote="yocto" path="poky/meta-cloud-services" revision="rocko"/>
 	<project name="bitbake" remote="openembedded" path="bitbake" revision="1.36"/>
-	<project name="openembedded-core" remote="openembedded" path="openembedded-core" revision="rocko"/>
-	<project name="meta-openembedded" remote="openembedded" path="meta-openembedded" revision="rocko"/>
-	<project name="meta-sdr" remote="balister" path="meta-sdr" revision="rocko"/>
-	<project name="meta-qt5" remote="qt5" path="meta-qt5" revision="rocko"/>
-	<project name="meta-ettus-1" remote="balister" path="meta-ettus" revision="rocko-updates"/>
-	<project name="meta-xilinx" remote="Xilinx" path="meta-xilinx" revision="rocko"/>
-	<project name="meta-redhawk-sdr" remote="geon" path="meta-redhawk-sdr" revision="master"/>
-	<project name="meta-redhawk-apps" remote="geon" path="meta-redhawk-apps" revision="rocko"/>
+  <project name="poky" remote="yocto" path="poky" revision="rocko"/>
+	<project name="openembedded-core" remote="openembedded" path="poky/openembedded-core" revision="rocko"/>
+	<project name="meta-openembedded" remote="openembedded" path="poky/meta-openembedded" revision="rocko"/>
+	<project name="meta-sdr" remote="balister" path="poky/meta-sdr" revision="rocko"/>
+	<project name="meta-qt5" remote="qt5" path="poky/meta-qt5" revision="rocko"/>
+	<project name="meta-ettus-1" remote="balister" path="poky/meta-ettus" revision="rocko-updates"/>
+	<project name="meta-xilinx" remote="Xilinx" path="poky/meta-xilinx" revision="rocko"/>
+	<project name="meta-redhawk-sdr" remote="geon" path="poky/meta-redhawk-sdr" revision="master"/>
+	<project name="meta-redhawk-apps" remote="geon" path="poky/meta-redhawk-apps" revision="rocko"/>
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -17,6 +17,6 @@
 	<project name="meta-qt5" remote="qt5" path="meta-qt5" revision="rocko"/>
 	<project name="meta-ettus-1" remote="balister" path="meta-ettus" revision="rocko-updates"/>
 	<project name="meta-xilinx" remote="Xilinx" path="meta-xilinx" revision="rocko"/>
-	<project name="meta-redhawk-sdr" remote="geon" path="meta-redhawk-sdr" revision="rocko"/>
+	<project name="meta-redhawk-sdr" remote="geon" path="meta-redhawk-sdr" revision="master"/>
 	<project name="meta-redhawk-apps" remote="geon" path="meta-redhawk-apps" revision="rocko"/>
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -8,6 +8,7 @@
 	<remote name="geon" fetch="https://github.com/GeonTech/" revision="master" />
 	<remote name="balister" fetch="git://github.com/balister" />
 	<remote name="qt5" fetch="https://github.com/meta-qt5/" />
+	<default remote="openembedded" revision="master"  />
 
 	<project name="bitbake" remote="openembedded" path="1.36"/>
 	<project name="openembedded-core" remote="openembedded" path="openembedded-core" revision="rocko"/>

--- a/default.xml
+++ b/default.xml
@@ -8,14 +8,13 @@
 	<remote name="geon" fetch="https://github.com/GeonTech/" revision="master" />
 	<remote name="balister" fetch="git://github.com/balister" />
 	<remote name="qt5" fetch="https://github.com/meta-qt5/" />
-	<default remote="openembedded" revision="master"  />
 
 	<project name="bitbake" remote="openembedded" path="1.36"/>
 	<project name="openembedded-core" remote="openembedded" path="openembedded-core" revision="rocko"/>
 	<project name="meta-openembedded" remote="openembedded" path="meta-openembedded" revision="rocko"/>
 	<project name="meta-sdr" remote="balister" path="meta-sdr" revision="rocko"/>
 	<project name="meta-qt5" remote="qt5" path="meta-qt5" revision="rocko"/>
-	<project name="meta-ettus" remote="ettus" path="meta-ettus" revision="rocko-updates"/>
+	<project name="meta-ettus-1" remote="balister" path="meta-ettus" revision="rocko-updates"/>
 	<project name="meta-xilinx" remote="Xilinx" path="meta-xilinx" revision="rocko"/>
 	<project name="meta-redhawk-sdr" remote="geon" path="meta-redhawk-sdr" revision="rocko"/>
 	<project name="meta-redhawk-apps" remote="geon" path="meta-redhawk-apps" revision="rocko"/>

--- a/default.xml
+++ b/default.xml
@@ -12,7 +12,7 @@
 
         <remote name="yocto"
                 fetch="git://git.yoctoproject.org/" />
- 
+
         <remote name="ettus"
                 fetch="http://github.com/EttusResearch" />
 
@@ -27,15 +27,15 @@
 
 	<default remote="openembedded" revision="master"  />
 
-	<project name="meta-cloud-services" remote="yocto" path="meta-cloud-services" revision="rocko"/>
-	<project name="meta-ettus" remote="ettus" path="meta-ettus" revision="rocko/n3xx"/>
-	<project name="bitbake"  path="bitbake" revision="1.36"/>
-	<project name="openembedded-core"  path="oe-core" revision="rocko"/>
-	<project name="meta-openembedded"  path="meta-oe" revision="rocko"/>
-	<project name="meta-xilinx" remote="Xilinx" path="meta-xilinx" revision="rocko"/>
-	<project name="meta-sdr" remote="balister" path="meta-sdr" revision="rocko"/>
-	<project name="meta-qt5" remote="qt5" path="meta-qt5" revision="rocko"/>
-	<project name="meta-redhawk-sdr" remote="geon" path="meta-redhawk-sdr" revision="rocko"/>
-	<project name="meta-redhawk-apps" remote="geon" path="meta-redhawk-apps" revision="rocko"/>
+	<project name="meta-cloud-services" remote="yocto" path="poky/meta-cloud-services" revision="rocko"/>
+	<project name="meta-ettus" remote="ettus" path="poky/meta-ettus" revision="rocko/n3xx"/>
+	<project name="bitbake"  path="poky/bitbake" revision="1.36"/>
+	<project name="openembedded-core"  path="poky/oe-core" revision="rocko"/>
+	<project name="meta-openembedded"  path="poky/meta-oe" revision="rocko"/>
+	<project name="meta-xilinx" remote="Xilinx" path="poky/meta-xilinx" revision="rocko"/>
+	<project name="meta-sdr" remote="balister" path="poky/meta-sdr" revision="rocko"/>
+	<project name="meta-qt5" remote="qt5" path="poky/meta-qt5" revision="rocko"/>
+	<project name="meta-redhawk-sdr" remote="geon" path="poky/meta-redhawk-sdr" revision="rocko"/>
+	<project name="meta-redhawk-apps" remote="geon" path="poky/meta-redhawk-apps" revision="rocko"/>
 
 </manifest>


### PR DESCRIPTION
This merge points the manifest to the release-named branch of meta-redhawk-sdr and includes instructions for how to create a fully-equipped, stand-alone REDHAWK Domain + GPP + FEI on the E3xx.